### PR TITLE
Python3 support

### DIFF
--- a/iminizinc/__init__.py
+++ b/iminizinc/__init__.py
@@ -1,4 +1,5 @@
-from mzn import MznMagics, checkMzn
+from __future__ import absolute_import
+from .mzn import MznMagics, checkMzn
 from IPython.core.display import display, HTML, Javascript
 from os import path
 
@@ -12,7 +13,7 @@ def load_ipython_extension(ipython):
     autoloaded by IPython at startup time.
     """
     # You can register the class itself without instantiating it.  IPython will
-    # call the default constructor on it.    
+    # call the default constructor on it.
     display(Javascript(initHighlighter))
     if checkMzn():
         ipython.register_magics(MznMagics)

--- a/iminizinc/mzn.py
+++ b/iminizinc/mzn.py
@@ -167,7 +167,7 @@ class MznMagics(Magics):
                     # Remove comments from output
                     cleanoutput = []
                     commentsoutput = []
-                    for l in solns2output.splitlines():
+                    for l in solns2output.decode().splitlines():
                         comment = re.search(r"^\s*%+\s*(.*)",l)
                         if comment:
                             commentsoutput.append(comment.group(1))

--- a/iminizinc/mzn.py
+++ b/iminizinc/mzn.py
@@ -83,22 +83,22 @@ class MznMagics(Magics):
         else:
             print("No solver given")
             return
-        
+
         mzn2fzn = ["mzn2fzn",mznlib]
         if args.verbose:
             mzn2fzn.append("-v")
         if args.statistics:
             mzn2fzn.append("-s")
-        
+
         if args.statistics:
             solver.append("-s")
         if args.all_solutions:
             solver.append("-a")
-        
+
         my_env = os.environ.copy()
 
         cwd = os.getcwd()
-        
+
         with TemporaryDirectory() as tmpdir:
             with open(tmpdir+"/model.mzn", "w") as modelf:
                 if cell is not None:
@@ -195,8 +195,8 @@ class MznMagics(Magics):
                                 self.shell.user_ns[var] = solution[var]
                                 print(var+"="+str(solution[var]))
                     return
-                    
-        
+
+
         # print("Full access to the main IPython object:", self.shell)
         # print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
         return
@@ -209,7 +209,7 @@ def checkMzn():
         if pipes.returncode != 0:
             print("Error while initialising extension: cannot run mzn2fzn. Make sure it is on the PATH when you run the Jupyter server.")
             return False
-        print(output.rstrip())
+        print(output.rstrip().decode())
     except OSError as e:
         print("Error while initialising extension: cannot run mzn2fzn. Make sure it is on the PATH when you run the Jupyter server.")
         return False


### PR DESCRIPTION
I noticed that the extension was not working with python 3.6. Using this PR the plugin should be usable with both python 2 and python 3. It includes the following changes:

- The import of `mzn` is now done using an relative import
- The `bytes` objects are decoded back to strings

Note that these changes should be checked with Python2, but should be compatible with both versions.

I'm sorry about the white space changes. (I'm afraid I forgot to commit selectively)