### PR TITLE
Anaconda support

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: 'iminizinc'
+  version: {{ GIT_DESCRIBE_TAG }}
+
+source:
+  git_url: .
+
+build:
+  number: {{ GIT_DESCRIBE_NUMBER }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - jupyter
+  run:
+    - python
+    - jupyter
+
+test:
+  imports:
+    - iminizinc
+
+about:
+  home: https://github.com/minizinc/iminizinc
+  license: Mozilla Public License 2.0 (MPL 2.0)
+  license_file: LICENSE.txt
+  summary: IPython extensions for the MiniZinc constraint modelling language


### PR DESCRIPTION
This PR adds a configuration to build and package for the anaconda package manager.

To build, package, and upload the iminizinc package run the following:

1. `conda build --output-folder build/ .` - generates a tar.bz2 file for your OS
2. `conda convert --platform all GENERATED_TARBAL -o build/` - generates tar.bz2 files for all other OSs
3. `anaconda upload build/*/*.tar.bz2` - Uploads all files to anaconda.org

Note that this configuration requires commits to be tagged with the version with git. For the current upload to [anaconda](https://anaconda.org/minizinc/iminizinc) I tagged 2d183b8 with `0.3`.

@guidotack I'll assume we'll discuss the access to the anaconda.org account offline.