### PR TITLE
Parsed Compiler and Solver Statistics

### DIFF
--- a/iminizinc/mzn.py
+++ b/iminizinc/mzn.py
@@ -24,7 +24,7 @@ class MznMagics(Magics):
         '-s',
         '--statistics',
         action='store_true',
-        help='Output statistics'
+        help='Return compiler and solver statistics. Statistics will be bound to "statistics" when using -m bound'
     )
     @magic_arguments.argument(
         '-m',


### PR DESCRIPTION
This PR parses the statistics as generated by the MiniZinc compiler and the two supported solvers. This would allow users to reuse the statistics in whatever way they see fit, instead of just having them on their display.

If the user uses the `return` option the `-s` flag will now return a tuple with `(solution, statistics)`, otherwise when the user uses the `bind` option the statistics our bound to the `statistics` variable.