### PR TITLE
Update iMiniZinc to work with the new MiniZinc driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,31 @@ If you want to find all solutions of a satisfaction problem, or all intermediate
              {u'queens': [3, 6, 2, 5, 1, 4]},
              {u'queens': [2, 4, 6, 1, 3, 5]}]
 
+You can also store your model to use the model iteratively:
+
+.. code::
+
+    In[1]:  %load_ext iminizinc
+
+    In[2]:  %%mzn_model queens
+
+            include "globals.mzn";
+            int: n;
+            array[1..n] of var 1..n: queens;
+            constraint all_different(queens);
+            constraint all_different([queens[i]+i | i in 1..n]);
+            constraint all_different([queens[i]-i | i in 1..n]);
+            solve satisfy;
+
+    In[3]:  for n in range(5,9):
+                x = %minizinc queens
+                print(x)
+
+    Out[3]: {'queens': [4, 2, 5, 3, 1]}
+            {'queens': [5, 3, 1, 6, 4, 2]}
+            {'queens': [6, 4, 2, 7, 5, 3, 1]}
+            {'queens': [4, 2, 7, 3, 6, 8, 5, 1]}
+
 The magic supports a number of additional options, in particular loading MiniZinc models and data from files. Some of these may only work with the development version of MiniZinc (i.e., not the one that comes with the bundled binary releases). You can take a look at the help using
 
 .. code::

--- a/iminizinc/mzn.py
+++ b/iminizinc/mzn.py
@@ -77,11 +77,11 @@ class MznMagics(Magics):
     @line_cell_magic
     def minizinc(self, line, cell=None):
         "MiniZinc magic"
-        mzn_proc = ["minizinc",solver]
+        mzn_proc = ["minizinc"]
 
         args = magic_arguments.parse_argstring(self.minizinc, line)
         if args.solver != "":
-            mzn_proc.append(["--solver", args.solver]
+            mzn_proc.extend(["--solver", args.solver])
         else:
             print("No solver given")
             return

--- a/iminizinc/mzn.py
+++ b/iminizinc/mzn.py
@@ -20,6 +20,8 @@ Solns2outArgs = [
     "--soln-separator",""
 ]
 
+MznModels = {}
+
 @magics_class
 class MznMagics(Magics):
 
@@ -103,6 +105,11 @@ class MznMagics(Magics):
 
         with TemporaryDirectory() as tmpdir:
             with open(tmpdir+"/model.mzn", "w") as modelf:
+                for m in args.model:
+                    mzn = MznModels.get(m)
+                    if mzn is not None:
+                        args.model.remove(m)
+                        modelf.write(mzn)
                 if cell is not None:
                     modelf.write(cell)
                 modelf.close()
@@ -177,6 +184,20 @@ class MznMagics(Magics):
         # print("Full access to the main IPython object:", self.shell)
         # print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
         return
+
+    @cell_magic
+    def mzn_model(self, line, cell):
+        args = magic_arguments.parse_argstring(self.minizinc, line)
+        if args.model == []:
+            print("No model name provided")
+            return
+        elif len(args.model) > 1:
+            print("Multigle model names provided")
+            return
+
+        MznModels[args.model[0]] = cell
+        return
+
 
 def checkMzn():
     try:

--- a/iminizinc/mzn.py
+++ b/iminizinc/mzn.py
@@ -100,7 +100,7 @@ class MznMagics(Magics):
         my_env = os.environ.copy()
 
         cwd = os.getcwd()
-        
+
         with TemporaryDirectory() as tmpdir:
             with open(tmpdir+"/model.mzn", "w") as modelf:
                 if cell is not None:
@@ -172,8 +172,8 @@ class MznMagics(Magics):
                                 self.shell.user_ns[var] = solution[var]
                                 print(var+"="+str(solution[var]))
                     return
-                    
-        
+
+
         # print("Full access to the main IPython object:", self.shell)
         # print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
         return


### PR DESCRIPTION
This PR updates the iminizinc python package to be compatible with the current development branch on the minizinc compiler/driver.

Changes:
- Solvers are now called using the minizinc driver. Any solver that has a solver configuration can now be used.
- Timeout has been disabled for now since there doesn't seem to be a standard flag for the timeout yet.